### PR TITLE
prefer defaults, use forge if defaults is unavailable. 

### DIFF
--- a/gds_stack.yml
+++ b/gds_stack.yml
@@ -1,6 +1,7 @@
 # Run `conda-env create -f install_gds_stack.yml`
 name: gds
 channels:
+  - defaults
   - conda-forge
 dependencies:
   - python=3


### PR DESCRIPTION
I think this will be more stable in the long run. Solves #4.

Also, when I use the existing install directions, it actually gives me numpy with openblas rather than mkl, even though you've got `mkl` in the install directives?

I think this is because the numpy that's in condaforge is built with openblas...