### PR TITLE
Add GeoPandas PostGIS dependencies

### DIFF
--- a/gds_py/Dockerfile
+++ b/gds_py/Dockerfile
@@ -47,6 +47,7 @@ RUN conda update conda --yes \
      'palettable' \
      'pandana' \
      'polyline' \
+     'psycopg2' \
      'pyarrow' \
      'pygeos' \
      'pyrosm' \
@@ -60,6 +61,7 @@ RUN conda update conda --yes \
      'scikit-learn' \
      'seaborn' \
      'spatialpandas' \
+     'sqlalchemy' \
      'statsmodels' \
      #'urbanaccess' \ https://github.com/UDST/urbanaccess/issues/63
      'xarray_leaflet' \
@@ -73,6 +75,7 @@ RUN conda update conda --yes \
 
 # pip libraries
 RUN pip install ablog \
+                geoalchemy2 \
                 jupyter-book \
                 keplergl \
                 pygeoda \


### PR DESCRIPTION
Added GeoAlchemy2, sqlachemy and psycopg2.

GeoAlchemy comes from pip because conda version is outdated. sqlalchemy is its dependency which can come from conda.