### PR TITLE
add dask-geopandas, remove press_theme

### DIFF
--- a/gds_py/gds_py_pip.txt
+++ b/gds_py/gds_py_pip.txt
@@ -6,4 +6,4 @@ keplergl
 pygeoda
 pytest-cov
 pytest-tornasync
-sphinx_press_theme
+git+git://github.com/jsignell/dask-geopandas


### PR DESCRIPTION
One note - we had to make some changes on geopandas master to fix some bugs in dask-geopandas, so some stuff will not work with 0.8.1 (like `apply`, but there's a workaround in https://github.com/jsignell/dask-geopandas/issues/18#issuecomment-699006105.

Also removing `sphinx_press_theme` which is not used in the end.