### PR TITLE
arm setup

### DIFF
--- a/gds_py/Dockerfile
+++ b/gds_py/Dockerfile
@@ -13,6 +13,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
     #&& mamba install --freeze-installed --yes --quiet \
 RUN mamba install --yes --quiet \
      'conda-forge::blas=*=openblas' \
+    'ablog' \
      'black' \
      'bokeh' \
      'boto3' \
@@ -27,19 +28,27 @@ RUN mamba install --yes --quiet \
      #'dask-ml' \ #  https://github.com/dask/dask-ml/issues/908
      'datashader' \
      'flake8' \
+    'geoalchemy2' \
      'geocube' \
      'geopandas' \
      'geopy' \
+    'gpxpy' \
      'gstools' \
      'h3-py' \
      'hdbscan' \
+    'hilbertcurve' \
      'ipyleaflet' \
      'ipympl' \
      'ipywidgets' \
      'jupyter_bokeh' \
+    'jupyter-book' \
+    'jupyter-server-proxy' \
      'jupytext' \
+    'jupyterlab-geojson' \
+    'jupyterlab-variableinspector' \
      'legendgram' \
      'lxml' \
+    'matplotlib-scalebar' \
      'momepy' \
      'nbdime' \
      'netCDF4' \
@@ -48,17 +57,21 @@ RUN mamba install --yes --quiet \
      'osmnx' \
      'palettable' \
      'pandana' \
+    'pint' \
      'pip' \
      'polyline' \
      'pooch' \
      'psycopg2' \
      'pyarrow' \
+    'pygeoda' \
      'pygeos' \
      'pyogrio' \
      'pyppeteer' \
      'pyrosm' \
      'pysal' \
      'pystac-client' \
+    'pytest-cov' \
+    'pytest-tornasync' \
      'rasterio' \
      'rasterstats' \
      'rio-cogeo' \
@@ -67,15 +80,18 @@ RUN mamba install --yes --quiet \
      'scikit-learn' \
      'scikit-mobility' \
      'seaborn' \
+    'similaritymeasures' \
      'spatialpandas' \
      'sqlalchemy' \
      'statsmodels' \
      'tabulate' \
+    'topojson' \
      'urbanaccess' \
      'xarray-spatial' \
      'xarray_leaflet' \
      'xlrd' \
-     'xlsxwriter' \
+    'xlsxwriter' \
+    'watermark' \
  && conda clean --all --yes --force-pkgs-dirs \
  && find /opt/conda/ -follow -type f -name '*.a' -delete \
  && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
@@ -86,9 +102,10 @@ RUN mamba install --yes --quiet \
 # pip libraries
 ADD ./gds_py_pip.txt ./
 RUN pip install -r gds_py_pip.txt \
- && pip cache purge \
- && rm -rf /home/$NB_USER/.cache/pip \
- && rm ./gds_py_pip.txt
+    && pip install trackintel --no-deps \
+    && pip cache purge \
+    && rm -rf /home/$NB_USER/.cache/pip \
+    && rm ./gds_py_pip.txt
 
 #--- Jupyter config ---#
 USER root

--- a/gds_py/gds_py_pip.txt
+++ b/gds_py/gds_py_pip.txt
@@ -1,21 +1,6 @@
-ablog
-geoalchemy2
-gpxpy
-hilbertcurve
-jupyterlab-geojson
-jupyter-book
-jupyter-server-proxy
-lckr-jupyterlab-variableinspector
-matplotlib-scalebar
 mobilkit
 pandas-bokeh
-pygeoda
 pymorton
-pytest-cov
-pytest-tornasync
 #simplification # Does not support Windows in Python3.9
 scikit-fusion
-topojson
-trackintel
 urbangrammar-graphics
-watermark


### PR DESCRIPTION
These are all the changes I needed to do to ensure the aarch64 version of `gds_py` correctly builds. In a nutshell, everything that can be installed from `conda-forge` is, plus `trackintel` is installed separately as `pip install trackintel --no-deps` because otherwise it breaks numba.

I haven't tried if the same builds on amd64.