### PR TITLE
Numba needs NumPy 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The `gds_env` stands on the shoulders of giants. Here are the core open technolo
 
 ## Community
 
-The `gds_env` is an open-source project. To join the conversation, please read through its [community guidelines](contributing).
+The `gds_env` is an open-source project. To join the conversation, please read through its [community guidelines](CONTRIBUTING.md).
 
 ## Citation
 

--- a/env/gds_amd64.yml
+++ b/env/gds_amd64.yml
@@ -45,6 +45,7 @@ dependencies:
   - pandana
   - pip
   - pip:
+    - numpy==2.0
     - matplotlib-scalebar
     - polars
     - polars-h3

--- a/env/gds_arm64.yml
+++ b/env/gds_arm64.yml
@@ -45,6 +45,7 @@ dependencies:
   - pandana
   - pip
   - pip:
+    - numpy==2.0
     - matplotlib-scalebar
     - polars
     - polars-h3


### PR DESCRIPTION
#### Description

PySAL requires Numba, and Numba needs NumPy<=2.0. Thus, Conda installs NumPy 1.26.4. However, Simplification needs NumPy>=2.0. Since Simplification is installed afterwards by Pip, which can't check the Numba constraint, Pip installs NumPy 2.2, released on 2024-12-08. 

```
Collecting numpy>=2.0.0 (from simplification->-r ~/repos/gds_env/env/condaenv.ae1m7tzg.requirements.txt (line 7))
  Downloading numpy-2.2.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (62 kB)
```

```{bash}
Installing collected packages: pymorton, polars-h3, polars, numpy, coverage, simplification, pytest-tornasync, watermark, pytest-cov, matplotlib-scalebar, urbangrammar-graphics
  Attempting uninstall: numpy
    Found existing installation: numpy 1.26.4
    Uninstalling numpy-1.26.4:
      Successfully uninstalled numpy-1.26.4
Successfully installed coverage-7.6.10 matplotlib-scalebar-0.9.0 numpy-2.2.2 polars-1.21.0 polars-h3-0.5.1 pymorton-1.0.5 pytest-cov-6.0.0 pytest-tornasync-0.6.0.post2 simplification-0.7.13 urbangrammar-graphics-1.2.3 watermark-2.5.0
```

That results in an error when importing the `esda` library.

```{bash}
$ python
Python 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:24:40) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pysal.explore import esda
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/pysal/explore/__init__.py", line 1, in <module>
    import esda
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/esda/__init__.py", line 10, in <module>
    from . import adbscan, shape  # noqa F401
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/esda/adbscan.py", line 12, in <module>
    from libpysal.cg.alpha_shapes import alpha_shape_auto
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/__init__.py", line 27, in <module>
    from . import cg, examples, graph, io, weights
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/examples/__init__.py", line 13, in <module>
    from .base import Example, example_manager
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/examples/base.py", line 19, in <module>
    from ..io import open as ps_open
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/io/__init__.py", line 2, in <module>
    from .iohandlers import *
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/io/iohandlers/__init__.py", line 3, in <module>
    from . import (
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/io/iohandlers/arcgis_dbf.py", line 3, in <module>
    from ...weights.util import remap_ids
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/weights/__init__.py", line 10, in <module>
    from .gabriel import Gabriel, Delaunay, Relative_Neighborhood
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/libpysal/weights/gabriel.py", line 11, in <module>
    from numba import njit
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/numba/__init__.py", line 59, in <module>
    _ensure_critical_deps()
  File "~/miniforge3/envs/gds/lib/python3.12/site-packages/numba/__init__.py", line 45, in _ensure_critical_deps
    raise ImportError(msg)
ImportError: Numba needs NumPy 2.0 or less. Got NumPy 2.2.
```

#### Solution

Add a constraint to Pip to install NumPy 2.0 in the yml environment specification.

```{yml}
  - pip:
    - numpy==2.0
```

```{bash}
Installing collected packages: pymorton, polars-h3, polars, numpy, coverage, simplification, pytest-tornasync, watermark, pytest-cov, matplotlib-scalebar, urbangrammar-graphics
  Attempting uninstall: numpy
    Found existing installation: numpy 1.26.4
    Uninstalling numpy-1.26.4:
      Successfully uninstalled numpy-1.26.4
Successfully installed coverage-7.6.10 matplotlib-scalebar-0.9.0 numpy-2.0.0 polars-1.21.0 polars-h3-0.5.1 pymorton-1.0.5 pytest-cov-6.0.0 pytest-tornasync-0.6.0.post2 simplification-0.7.13 urbangrammar-graphics-1.2.3 watermark-2.5.0
```

The `esda` library now loads correctly.

```{bash}
$ python
Python 3.12.8 | packaged by conda-forge | (main, Dec  5 2024, 14:24:40) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pysal.explore import esda
>>> 
```
