### PR TITLE
Add Frogmouth to base image via pipx

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -56,7 +56,10 @@ RUN $HOME/scripts/install_latex_tools.sh
 
 #---    Vim   ---#
 ADD ./dev/vimrc $HOME/.vimrc
-RUN $HOME/scripts/install_vim.sh 
+RUN $HOME/scripts/install_vim.sh
+
+#--- Frogmouth ---#
+RUN $HOME/scripts/install_frogmouth.sh
 
 #---    GPQ   ---#
 RUN $HOME/scripts/install_gpq.sh 

--- a/env/installers/install_frogmouth.sh
+++ b/env/installers/install_frogmouth.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#######################
+### Frogmouth setup ###
+#######################
+
+# Frogmouth: Textual-based TUI markdown browser.
+# Installed via pipx into a shared system location, using the system Python,
+# so it stays fully isolated from the `gds` and `dev` conda environments.
+
+export PIPX_HOME=/opt/pipx
+export PIPX_BIN_DIR=/usr/local/bin
+
+apt-get update \
+ && apt-get install -y --no-install-recommends pipx \
+ && pipx install frogmouth \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get autoclean \
+ && apt-get autoremove \
+ && apt-get clean


### PR DESCRIPTION
Install Frogmouth (Textual-based TUI markdown browser) into a shared system location using the system Python and pipx, isolated from the `gds` and `dev` conda environments. Placed in the base image so it is available across all flavours (gds_py, gds, gds_dev).

- New installer: env/installers/install_frogmouth.sh
- Wired into env/Dockerfile after the Vim block, in the root layer
- PIPX_HOME=/opt/pipx, PIPX_BIN_DIR=/usr/local/bin