### PR TITLE
fix(gdsa): guard empty array expansion for bash 3.2 (macOS)

### DIFF
--- a/utils/gdsa
+++ b/utils/gdsa
@@ -196,8 +196,8 @@ _cmd_claude() {
   exec docker run --rm -it \
     -v "${path}:${WORKDIR}" \
     -w "${WORKDIR}" \
-    "${MOUNTS[@]}" \
-    "${ENVS[@]}" \
+    ${MOUNTS[@]+"${MOUNTS[@]}"} \
+    ${ENVS[@]+"${ENVS[@]}"} \
     "$IMAGE" \
     claude --dangerously-skip-permissions
 }
@@ -225,8 +225,8 @@ _cmd_copilot() {
   exec docker run --rm -it \
     -v "${path}:${WORKDIR}" \
     -w "${WORKDIR}" \
-    "${MOUNTS[@]}" \
-    "${ENVS[@]}" \
+    ${MOUNTS[@]+"${MOUNTS[@]}"} \
+    ${ENVS[@]+"${ENVS[@]}"} \
     "$IMAGE" \
     copilot --allow-all
 }
@@ -303,8 +303,8 @@ _cmd_opencode() {
     --add-host "${hostname}:${resolved_ip}" \
     -v "${path}:${WORKDIR}" \
     -w "${WORKDIR}" \
-    "${MOUNTS[@]}" \
-    "${ENVS[@]}" \
+    ${MOUNTS[@]+"${MOUNTS[@]}"} \
+    ${ENVS[@]+"${ENVS[@]}"} \
     "$IMAGE" \
     opencode
 }
@@ -320,7 +320,7 @@ _cmd_shell() {
   exec docker run --rm -it \
     -v "${path}:${WORKDIR}" \
     -w "${WORKDIR}" \
-    "${MOUNTS[@]}" \
+    ${MOUNTS[@]+"${MOUNTS[@]}"} \
     "$IMAGE" \
     bash
 }


### PR DESCRIPTION
Under `set -euo pipefail`, bash 3.2 (shipped by macOS) throws "unbound variable" when expanding an empty array with "${ARR[@]}". `gdsa claude` hit this whenever ENVS stayed empty (no ANTHROPIC_API_KEY, GITHUB_TOKEN, or GH_TOKEN in the host env).

Switch MOUNTS/ENVS expansions to the portable ${ARR[@]+"${ARR[@]}"} idiom: expands to zero args when empty, preserves quoted elements otherwise. Verified identical behavior on bash 3.2.57, 4.4.23, and 5.3.15.