### PR TITLE
Add Typst to base image via static binary

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -52,7 +52,10 @@ RUN $HOME/scripts/install_decktape.sh
 #--- LaTeX tools ---#
 ADD ./dev/texBuild.py $HOME/
 ADD ./dev/install_texbuild.py $HOME/
-RUN $HOME/scripts/install_latex_tools.sh 
+RUN $HOME/scripts/install_latex_tools.sh
+
+#--- Typst ---#
+RUN $HOME/scripts/install_typst.sh
 
 #---    Vim   ---#
 ADD ./dev/vimrc $HOME/.vimrc

--- a/env/installers/install_typst.sh
+++ b/env/installers/install_typst.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+####################
+### Install Typst ###
+####################
+
+# Typst: markup-based typesetting system, installed as a static binary.
+# Complements the LaTeX toolchain and is also usable outside Quarto's
+# bundled `quarto typst` command (e.g. for authoring plain .typ files).
+
+export ARCH=$(dpkg --print-architecture)
+
+case "$ARCH" in
+  amd64) export TYPST_ARCH="x86_64" ;;
+  arm64) export TYPST_ARCH="aarch64" ;;
+  *) echo "Unsupported architecture for Typst: $ARCH" && exit 1 ;;
+esac
+
+export TYPST_TARGET="typst-${TYPST_ARCH}-unknown-linux-musl"
+
+mkdir $HOME/typst \
+ && wget -O $HOME/typst/typst.tar.xz https://github.com/typst/typst/releases/latest/download/$TYPST_TARGET.tar.xz \
+ && cd $HOME/typst \
+ && tar -xJf typst.tar.xz \
+ && mv $TYPST_TARGET/typst /usr/bin/ \
+ && cd $HOME \
+ && rm -rf typst


### PR DESCRIPTION
## Summary
- Adds `env/installers/install_typst.sh`, installing the latest Typst release (static musl binary, arch-mapped for amd64/arm64) to `/usr/bin/typst` — no pinned version, always tracks GitHub's `latest` release.
- Wires the installer into `env/Dockerfile` right after the LaTeX tools step.

Typst is a lightweight (~17MB), dependency-free complement to the existing LaTeX toolchain, and enables standalone `.typ` authoring outside of Quarto's bundled `quarto typst` command.

## Test plan
- [x] Verified both amd64 and arm64 release asset URLs resolve
- [x] Downloaded and extracted the archive locally, confirmed `typst --version` runs
- [ ] Full image build (not run locally — no Docker available in this environment)