### PR TITLE
DeckTape/Chrome consolidation + jupyter-book PDF fix (audit 1.2, 1.3, 3.8)

### DIFF
--- a/env/dev/check_dev_stack.ipynb
+++ b/env/dev/check_dev_stack.ipynb
@@ -80,6 +80,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jupyter-book-version",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! jupyter-book --version"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "functional-header",
    "metadata": {},
@@ -359,6 +369,75 @@
     "print(f'PASS: tippecanoe created MBTiles ({mbtiles_size:,} bytes)')\n",
     "os.remove('/tmp/test.mbtiles')\n",
     "os.remove('/tmp/test_points.geojson')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "jupyter-book-section",
+   "metadata": {},
+   "source": [
+    "### `jupyter-book` — PDF export (LaTeX and Typst)\n",
+    "\n",
+    "Builds a minimal MyST document to PDF two ways: `--pdf` (via LaTeX — `latexmk` +\n",
+    "`xelatex`) and `--typst` (via the `typst` binary). This exercises the full\n",
+    "PDF-export toolchain that Jupyter Book 2.x uses. Unlike the other checks this one\n",
+    "needs network access: MyST fetches its export templates from `api.mystmd.org`.\n",
+    ""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "jupyter-book-pdf-run",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import subprocess\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "# jupyter-book 2.x renders PDF from MyST: --pdf goes through LaTeX (latexmk +\n",
+    "# xelatex), --typst through the typst binary. Both fetch a template over the\n",
+    "# network (all image builds have network anyway).\n",
+    "book_md = \"\"\"\\\n",
+    "---\n",
+    "title: GDS PDF Test\n",
+    "authors:\n",
+    "  - name: GDS\n",
+    "---\n",
+    "# Intro\n",
+    "\n",
+    "jupyter-book PDF export functional test. Inline math: $e^{i\\\\pi} + 1 = 0$.\n",
+    "\"\"\"\n",
+    "\n",
+    "def _check_pdf(pdfs, label):\n",
+    "    assert pdfs, f'{label}: no PDF produced'\n",
+    "    data = pdfs[0].read_bytes()\n",
+    "    assert data.startswith(b'%PDF-'), f'{label}: output is not a PDF ({pdfs[0]})'\n",
+    "    assert len(data) > 1000, f'{label}: PDF suspiciously small ({len(data)} bytes)'\n",
+    "    return pdfs[0], len(data)\n",
+    "\n",
+    "with tempfile.TemporaryDirectory(prefix='gds-jb-') as tmpdir:\n",
+    "    src = Path(tmpdir) / 'gds_jb.md'\n",
+    "    src.write_text(book_md)\n",
+    "\n",
+    "    for builder in ('--pdf', '--typst'):\n",
+    "        result = subprocess.run(\n",
+    "            ['jupyter-book', 'build', str(src), builder],\n",
+    "            capture_output=True, text=True, cwd=tmpdir,\n",
+    "        )\n",
+    "        if result.returncode != 0:\n",
+    "            print(result.stdout[-2000:])\n",
+    "            print('--- stderr ---')\n",
+    "            print(result.stderr[-2000:])\n",
+    "            raise RuntimeError(f'jupyter-book build {builder} exited {result.returncode}')\n",
+    "\n",
+    "    exports = Path(tmpdir) / '_build' / 'exports'\n",
+    "    latex_pdf, latex_size = _check_pdf(list(exports.glob('*.pdf')), 'jupyter-book --pdf')\n",
+    "    typst_pdf, typst_size = _check_pdf(list(exports.glob('*_typst/*.pdf')), 'jupyter-book --typst')\n",
+    "    print(f'PASS: jupyter-book --pdf   -> {latex_pdf.name} ({latex_size:,} bytes)')\n",
+    "    print(f'PASS: jupyter-book --typst -> {typst_pdf.name} ({typst_size:,} bytes)')\n",
+    ""
    ]
   }
  ],

--- a/env/gds_amd64.yml
+++ b/env/gds_amd64.yml
@@ -66,7 +66,6 @@ dependencies:
   - protobuf
   - psycopg2
   - pyarrow
-  - pyppeteer
   - pyrosm
   - pysal
   - pystac-client

--- a/env/gds_arm64.yml
+++ b/env/gds_arm64.yml
@@ -65,7 +65,6 @@ dependencies:
   - protobuf
   - psycopg2
   - pyarrow
-  - pyppeteer
   - pyrosm
   - pysal==24.7
   - pystac-client

--- a/env/installers/install_conda_env.sh
+++ b/env/installers/install_conda_env.sh
@@ -5,7 +5,6 @@
 mamba env create -f gds.yml \
  && source activate gds \
  && python -m ipykernel install --user --name gds --display-name "GDS-$GDS_ENV_VERSION" \
- && pyppeteer-install \
  && conda deactivate \
  && rm ./gds.yml \
  && conda clean --yes --all --force-pkgs-dirs \

--- a/env/installers/install_decktape.sh
+++ b/env/installers/install_decktape.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 
 # https://jupyterbook.org/advanced/pdf.html#build-a-pdf-from-your-book-html
 # https://github.com/astefanutti/decktape/issues/187
+#
+# Runtime shared libraries Chromium links against. These are the *runtime*
+# packages only — Chrome needs the .so libraries, not the -dev headers, so no
+# `*-dev` packages are installed here (audit 1.3).
 apt-get update -qq \
  && apt-get install -y --no-install-recommends \
     libasound2t64 \
@@ -45,98 +49,54 @@ apt-get update -qq \
     libgbm1 \
     libnss3 \
     lsb-release \
-    unzip \
     xdg-utils \
     wget \
-    libcairo2-dev \
-    libasound2-dev \
-    libpangocairo-1.0-0 \
-    libx11-xcb-dev \
-    libxcursor-dev \
-    libxdamage-dev \
-    libxi-dev \
-    libxtst-dev \
-    libxss-dev \
-    libxrandr-dev \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get autoclean \
  && apt-get autoremove \
  && apt-get clean
 
-export ARCH=$(dpkg --print-architecture)
-
 decktape_browser_dir=/opt/decktape-browser
 decktape_browser_bin=/usr/local/bin/decktape-chrome
 
-case "$ARCH" in
-  amd64)
-    decktape_browser_source="puppeteer"
-    ;;
-  arm64)
-    decktape_browser_source="playwright"
-    ;;
-  *)
-    echo "Unsupported architecture for DeckTape browser: $ARCH" >&2
-    exit 1
-    ;;
-esac
-
 mkdir -p "$decktape_browser_dir"
 
-mkdir $HOME/.decktape \
- && fix-permissions $HOME/.decktape
+mkdir "$HOME/.decktape" \
+ && fix-permissions "$HOME/.decktape"
 
+# Install DeckTape (latest) plus a Chromium for it.
+#
+# We fetch Chromium with Playwright on BOTH architectures. Playwright ships
+# prebuilt Linux Chromium for amd64 and arm64, so this replaces the old per-arch
+# puppeteer(amd64)/playwright(arm64) split — a source of the historical
+# amd64-vs-arm64 divergence. Playwright installs into a deterministic layout,
+# `$PLAYWRIGHT_BROWSERS_PATH/chromium-<rev>/chrome-linux/chrome`, so a single
+# glob resolves the binary; the previous find-cascade + zip fallbacks are gone.
+# Nothing is version-pinned — DeckTape and Chromium track latest (see the
+# repo's "latest for tools" policy); robustness comes from the deterministic
+# install path, not from a pin.
 npm install -g decktape \
- && npm cache clean --force \
- && decktape_bin="$(command -v decktape)" \
- && decktape_real_bin="$(readlink -f "$decktape_bin")" \
- && decktape_package_dir="$(cd "$(dirname "$decktape_real_bin")" && pwd)" \
- && decktape_node_modules="$decktape_package_dir/node_modules" \
- && if [[ "$decktape_browser_source" == "puppeteer" ]]; then \
-      PUPPETEER_CACHE_DIR="$decktape_browser_dir" \
-        node "$decktape_node_modules/puppeteer/install.mjs"; \
-    else \
-      PLAYWRIGHT_BROWSERS_PATH="$decktape_browser_dir" \
-        npx --yes playwright@latest install chromium; \
-    fi \
- && echo "=== decktape browser cache ===" \
- && find "$decktape_browser_dir" | sort \
- && echo "==============================" \
- && decktape_bin_dir="$(dirname "$decktape_bin")" \
- && chmod -R a+rX "$decktape_browser_dir" \
- && chrome_bin="$(find "$decktape_browser_dir" \
-      \( -path '*/chrome-linux/chrome' \
-      -o -path '*/chrome-linux64/chrome' \
-      -o -path '*/chrome-headless-shell/chrome-headless-shell' \
-      -o -path '*/chrome-headless-shell-linux64/chrome-headless-shell' \) \
-      -type f | sort | tail -n 1)" \
- && if [[ -z "$chrome_bin" ]]; then \
-      chrome_zip="$(find "$decktape_browser_dir"/chrome -name '*-chrome-linux64.zip' -type f | sort | tail -n 1)"; \
-      if [[ -n "$chrome_zip" ]]; then \
-        mkdir -p "$decktape_browser_dir/manual-extract/chrome"; \
-        unzip -oq "$chrome_zip" -d "$decktape_browser_dir/manual-extract/chrome"; \
-        chrome_bin="$(find "$decktape_browser_dir/manual-extract/chrome" \
-          \( -path '*/chrome-linux/chrome' \
-          -o -path '*/chrome-linux64/chrome' \) \
-          -type f | sort | tail -n 1)"; \
-      fi; \
-    fi \
- && if [[ -z "$chrome_bin" ]]; then \
-      headless_zip="$(find "$decktape_browser_dir"/chrome-headless-shell -name '*-chrome-headless-shell-linux64.zip' -type f | sort | tail -n 1)"; \
-      if [[ -n "$headless_zip" ]]; then \
-        mkdir -p "$decktape_browser_dir/manual-extract/chrome-headless-shell"; \
-        unzip -oq "$headless_zip" -d "$decktape_browser_dir/manual-extract/chrome-headless-shell"; \
-        chrome_bin="$(find "$decktape_browser_dir/manual-extract/chrome-headless-shell" \
-          \( -path '*/chrome-headless-shell/chrome-headless-shell' \
-          -o -path '*/chrome-headless-shell-linux64/chrome-headless-shell' \) \
-          -type f | sort | tail -n 1)"; \
-      fi; \
-    fi \
- && test -n "$chrome_bin" \
- && printf 'Resolved DeckTape Chrome path: %s\n' "$chrome_bin" \
- && test -e "$chrome_bin" \
- && chmod a+rx "$chrome_bin" \
- && test -x "$chrome_bin" \
- && ln -sf "$chrome_bin" "$decktape_browser_bin" \
- && mv "$decktape_bin_dir/decktape" "$decktape_bin_dir/decktape.real" \
- && install -m 755 "$HOME/scripts/decktape_wrapper.sh" "$decktape_bin_dir/decktape"
+ && npm cache clean --force
+
+PLAYWRIGHT_BROWSERS_PATH="$decktape_browser_dir" \
+    npx --yes playwright@latest install chromium
+
+chrome_bin="$(ls -d "$decktape_browser_dir"/chromium-*/chrome-linux/chrome | sort | tail -n 1)"
+test -n "$chrome_bin"
+test -x "$chrome_bin"
+printf 'Resolved DeckTape Chrome path: %s\n' "$chrome_bin"
+
+chmod -R a+rX "$decktape_browser_dir"
+ln -sf "$chrome_bin" "$decktape_browser_bin"
+
+# Swap the DeckTape entrypoint for our wrapper (injects --no-sandbox /
+# --disable-dev-shm-usage inside Docker and resolves the browser path).
+decktape_bin="$(command -v decktape)"
+decktape_bin_dir="$(dirname "$decktape_bin")"
+mv "$decktape_bin_dir/decktape" "$decktape_bin_dir/decktape.real"
+install -m 755 "$HOME/scripts/decktape_wrapper.sh" "$decktape_bin_dir/decktape"
+
+# In-layer permission fix: the npm global install lands in the conda prefix and
+# the browser under /opt; fix what we touched here so no later pass copies the
+# conda tree up (audit 1.1 hygiene).
+fix-permissions "${CONDA_DIR}" "${HOME}"

--- a/env/installers/install_latex_tools.sh
+++ b/env/installers/install_latex_tools.sh
@@ -17,6 +17,9 @@ mkdir texcount_tmp \
  && rm -rf texcount_tmp
 
 #--- LaTeX packages ---#
+# latexmk drives jupyter-book's `--pdf` export (myst -> TeX -> latexmk); without
+# it `jupyter-book build --pdf` fails with "latexmk: not found". The TeX engines
+# themselves (xelatex/pdflatex) are already present.
 apt-get update -qq \
- && apt-get install -y --no-install-recommends fonts-lmodern \
+ && apt-get install -y --no-install-recommends fonts-lmodern latexmk \
  && rm -rf /var/lib/apt/lists/*

--- a/frontend_code/Dockerfile
+++ b/frontend_code/Dockerfile
@@ -5,8 +5,8 @@ USER root
 
 RUN curl -fsSL https://code-server.dev/install.sh | sh
 
-RUN apt-get update \
- && apt-get install -y latexmk
+# latexmk is provided by the base gds image (env/installers/install_latex_tools.sh),
+# which gds_code builds on top of — no need to install it again here.
 
 RUN /usr/bin/code-server \
      --install-extension quarto.quarto \


### PR DESCRIPTION
## Summary

Consolidates the image down to **one browser** and fixes **jupyter-book PDF export**, covering audit findings **1.2**, **1.3**, **3.8**, plus a bug found along the way. Investigated and validated end-to-end inside a running **arm64 gds env**, which corrected two stale assumptions in the audit (see below).

Branch is stacked on `claude/repo-improvement-review-nc26d2` (the audit branch) and targets it for a clean 4-commit diff.

## What changed

| Finding | Change |
|---|---|
| **1.2** | Delete the vestigial `pyppeteer` package + its bundled Chromium (`pyppeteer-install`). Jupyter Book 2.x no longer uses it; nothing else does. Removes ~150–180 MB + a second browser. |
| **3.8** | Rewrite `install_decktape.sh`: fetch Chromium with **Playwright on both arches** (was puppeteer on amd64 / playwright on arm64) and resolve it with a **single glob** over Playwright's deterministic layout — deleting the ~75-line find→unzip→headless-shell fallback cascade. **No pinning** (decktape/chromium stay latest; robustness comes from the deterministic path). |
| **1.3** | Drop DeckTape's 9 `*-dev` header packages + the duplicate `libpangocairo-1.0-0` (Chrome links runtime `.so`s, not headers). |
| bug fix | Add `latexmk` to the base gds image so `jupyter-book build --pdf` works (it was failing with `latexmk: not found`); remove the now-redundant `latexmk` install from `gds_code`, which inherits it. |
| test gate | Add jupyter-book `--pdf` (LaTeX) and `--typst` functional tests to `env/dev/check_dev_stack.ipynb`. |

## Why the plan differs from the audit text

The audit was written against an older tree. Running in a live arm64 gds env showed:

- **Jupyter Book is v2.1.6 (mystmd)** — its `--pdf` renders via **LaTeX/Typst, not a headless browser**. So the audit's "point pyppeteer at decktape-chrome" plan (1.2) is moot: `pyppeteer` is simply **dead weight** and gets deleted. DeckTape is now the only browser consumer.
- That also surfaced a real bug: **`jupyter-book --pdf` was broken** (`latexmk` missing) — fixed here.
- 3.8's simplification needs **no version pin**: determinism comes from Playwright's fixed `chromium-*/chrome-linux/chrome` layout, so we stay on latest per the repo's "latest for tools" policy.

## Validation (in-session, arm64)

- ✅ `npx playwright@latest install chromium` → glob resolves the unique `chromium-<rev>/chrome-linux/chrome` → **decktape drives it to a valid `%PDF`** (3 slides).
- ✅ The existing dev-notebook decktape test still passes.
- ✅ `jupyter-book --pdf` (≈29 KB via xelatex) and `--typst` (≈20 KB via typst) succeed with `latexmk` on PATH; the new test cell's logic passes.
- ✅ `bash -n` + `shellcheck -S warning` clean on all edited scripts.

## Left for the maintainer (merge gate)

- **`make test` (test_dev) on both arches after a rebuild** — the agreed blocker. **amd64** is the one path not exercised in-session (Playwright behaves identically there; low risk).
- **Merge order:** commit `97d060f` rewrites `install_decktape.sh`, which the `audit/docker-layer-hygiene` branch also touches (it adds the same in-layer `fix-permissions`). On merge, **take this rewrite** — it already includes the fix-permissions.
- Generated `env/py/stack_*.md` still list `pyppeteer`; they regenerate on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
