### PR TITLE
Per-layer Docker cleanup: stop duplicating the conda tree (audit 1.1)

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -30,11 +30,13 @@ RUN $HOME/scripts/install_conda_env.sh
 
 USER root
 
-#--- Quarto ---#
+#--- System apt packages (xz-utils for Quarto, htop) ---#
 RUN apt-get update \
- && apt-get install -y --no-install-recommends xz-utils \
+ && apt-get install -y --no-install-recommends xz-utils htop \
  && rm -rf /var/lib/apt/lists/*
-RUN $HOME/scripts/install_quarto.sh 
+
+#--- Quarto ---#
+RUN $HOME/scripts/install_quarto.sh
 
 #--- Jekyll ---#
 RUN $HOME/scripts/install_jekyll.sh 
@@ -42,12 +44,8 @@ RUN $HOME/scripts/install_jekyll.sh
 #--- tippecanoe ---#
 RUN $HOME/scripts/install_tippecanoe.sh 
 
-#--- htop ---#
-RUN apt-get update \
- && apt-get install -y --no-install-recommends htop
-
 #--- Decktape ---#
-RUN $HOME/scripts/install_decktape.sh 
+RUN $HOME/scripts/install_decktape.sh
 
 #--- LaTeX tools ---#
 ADD ./dev/texBuild.py $HOME/
@@ -68,25 +66,17 @@ RUN $HOME/scripts/install_frogmouth.sh
 RUN $HOME/scripts/install_gpq.sh 
 
 #--- Clean up ---#
-RUN fix-permissions $HOME \
-  && fix-permissions $CONDA_DIR
-
-RUN cd $NB_HOME \
- && rm -rf /tmp/downloaded_packages/ /tmp/*.rds \
- && rm -rf $GEM_HOME/cache \
- && rm -rf /usr/local/bundle/cache \
- && apt-get autoclean \
- && apt-get autoremove \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- && rm -rf $HOME/scripts
+# Cleanup is now done per-layer: each installer fixes permissions and clears its
+# own apt lists / package caches in the same RUN that created them (see
+# env/installers/*.sh). On overlayfs, cleanup only reclaims space when it runs in
+# the layer that added the files, so the old standalone fix-permissions / rm /
+# find layers here reclaimed nothing and the fix-permissions $CONDA_DIR pass in
+# particular duplicated the multi-GB conda tree into an extra layer.
+# The only cross-cutting leftover is the scripts staging dir, which every RUN
+# above sources from, so it can only be removed after the last installer (as
+# root, since it was ADDed root-owned).
+RUN rm -rf $HOME/scripts
 
 USER $NB_UID
-
-RUN find /opt/conda/ -follow -type f -name '*.a' -delete \
- && find /opt/conda/ -follow -type f -name '*.pyc' -delete \
- && find /opt/conda/ -follow -type f -name '*.js.map' -delete \
- && pip cache purge \
- && rm -rf $HOME/.cache/pip
 
 RUN echo "Completing build at: $(date)"

--- a/env/installers/install_conda_env.sh
+++ b/env/installers/install_conda_env.sh
@@ -28,6 +28,12 @@ jupyter lab --generate-config \
  /home/${NB_USER}/.jupyter/jupyter_lab_config.py \
  && echo "c.KernelSpecManager.whitelist = {'gds', 'ir', 'bash'}" >> \
  /home/${NB_USER}/.jupyter/jupyter_lab_config.py \
- && jupyter kernelspec remove -y python3 
+ && jupyter kernelspec remove -y python3
+
+#--- Permissions & tmp cleanup (same layer) ---#
+# Fix permissions on the freshly created gds env in the SAME layer that built it
+# (files are new here, so no overlayfs copy-up) and drop R build tmp files.
+rm -rf /tmp/downloaded_packages /tmp/*.rds
+fix-permissions "${CONDA_DIR}"
 
 

--- a/env/installers/install_decktape.sh
+++ b/env/installers/install_decktape.sh
@@ -140,3 +140,8 @@ npm install -g decktape \
  && ln -sf "$chrome_bin" "$decktape_browser_bin" \
  && mv "$decktape_bin_dir/decktape" "$decktape_bin_dir/decktape.real" \
  && install -m 755 "$HOME/scripts/decktape_wrapper.sh" "$decktape_bin_dir/decktape"
+
+# `npm install -g decktape` lands in the base conda prefix as root; fix its
+# permissions (and anything written under $HOME) in this same layer so a later
+# pass never has to copy the conda tree up.
+fix-permissions "${CONDA_DIR}" "${HOME}"

--- a/env/installers/install_jekyll.sh
+++ b/env/installers/install_jekyll.sh
@@ -10,7 +10,7 @@ gem install sass-embedded
 gem install sass --force sass-embedded
 gem install jekyll bundler github-pages jekyll-scholar just-the-docs
 
-rm -rf /var/lib/gems/3.0.0/cache/*
+rm -rf /var/lib/gems/*/cache/* /usr/local/bundle/cache
 rm -rf /var/lib/apt/lists/* \
  && apt-get autoclean \
  && apt-get autoremove \

--- a/env/installers/install_jupyter_dev.sh
+++ b/env/installers/install_jupyter_dev.sh
@@ -25,9 +25,12 @@ pip install \
          jupytext
 # Bash kernel
 python -m bash_kernel.install
-# Clean
+# Clean (in-layer: caches purged and permissions fixed in the same RUN as the
+# install so the base-env additions are group-writable before any later
+# fix-permissions pass, avoiding a cross-layer copy-up of /opt/conda)
 pip cache purge \
  && conda clean --all --yes --force-pkgs-dirs \
  && jupyter lab clean -y \
- && npm cache clean --force
+ && npm cache clean --force \
+ && fix-permissions "${CONDA_DIR}"
 

--- a/env/installers/install_quarto.sh
+++ b/env/installers/install_quarto.sh
@@ -12,3 +12,7 @@ wget "$QUARTO_DL_URL" -O quarto.deb \
  && quarto install tinytex \
  && rm quarto.deb
 
+# `quarto install tinytex` writes TinyTeX under $HOME as root; hand it back to
+# the notebook user in the same layer so nothing is copied up later.
+fix-permissions "${HOME}"
+

--- a/env/installers/install_tippecanoe.sh
+++ b/env/installers/install_tippecanoe.sh
@@ -10,4 +10,10 @@ cd $HOME/tippecanoe \
  && cd .. \
  && rm -rf $HOME/tippecanoe
 
+# Drop the apt lists in-layer (this script runs apt-get update above but the
+# old standalone cleanup layer used to remove them; keep it self-contained).
+# NOTE: build-essential/libsqlite3-dev are still left in the image — that is
+# finding 1.4 (multi-stage build), out of scope here.
+rm -rf /var/lib/apt/lists/*
+
 

--- a/env/installers/install_vim.sh
+++ b/env/installers/install_vim.sh
@@ -14,3 +14,7 @@ apt-get update \
  && apt-get autoremove \
  && apt-get clean
 
+# .vim/ and the root-owned .vimrc (ADDed in the Dockerfile) belong to the
+# notebook user; fix them in-layer.
+fix-permissions "${HOME}"
+


### PR DESCRIPTION
## Summary

Restructures `env/Dockerfile` cleanup into **per-layer hygiene** (audit finding **1.1**), removing the multi-GB duplication of the conda tree. Measured **~3.2 GB smaller** on arm64 (18.9 GB → 15.7 GB).

## The problem

On overlayfs a layer can only *add* bytes, so the standalone cleanup layers at the end of `env/Dockerfile` reclaimed nothing — and worse, `fix-permissions $CONDA_DIR` run as its **own** layer chmod'd the freshly-installed `gds` env (created `644`, not group-writable) and copied the whole multi-GB tree up into an extra layer.

## The fix

Move all cleanup **in-layer** with the `RUN` that created the files:

- `install_jupyter_dev.sh` / `install_conda_env.sh`: `fix-permissions $CONDA_DIR` at the end of each conda-modifying `RUN`, so base-env and gds-env additions are group-writable *in their own layer* — no later pass copies `/opt/conda` up.
- `install_quarto.sh` (TinyTeX), `install_vim.sh` (`.vim`/`.vimrc`), `install_decktape.sh` (npm-global + `.decktape`): `fix-permissions` on the paths they write, in their own root layers.
- Absorb the scattered `rm`s into the layers that own them: `/tmp` R junk → `install_conda_env.sh`; gem/bundle cache → `install_jekyll.sh`; apt lists → `install_tippecanoe.sh`.
- Fold the incomplete `htop` apt layer into the `xz-utils` apt layer (which already removes `/var/lib/apt/lists/*`).
- Delete the three standalone cleanup layers; keep only a root `rm -rf $HOME/scripts` (scripts must persist until the last installer sources them).
- Drop the trailing `find … -delete && pip cache purge` layer — `install_conda_env.sh` already runs that identical pass in-layer over `/opt/conda`.

## Validation

- ✅ `bash -n` + `shellcheck -S warning` clean on all edited scripts.
- ✅ Image size measured by maintainer: **18.9 GB → 15.7 GB** (arm64), consistent with removing the duplicated gds-env copy.
- ⏳ Remaining (maintainer): `make test` on both arches, and a `docker history`/`dive` before-after to confirm the standalone `fix-permissions` layer is gone.

## Notes

- Deliberately **out of scope** (noted, not touched): `build-essential` in tippecanoe (1.4), pyppeteer's Chromium (1.2), malformed `ENV LANG` (2.3), undefined `$NB_HOME` (2.10), pre-existing shellcheck SC2155/SC2148 (3.4).
- **Merge-order with #104:** both touch `install_decktape.sh` — this PR adds an in-layer `fix-permissions`; #104 rewrites the file and already includes it. Whoever merges second, **take #104's version**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
