### PR TITLE
fix(env): make amd64 image build + jb --pdf work end-to-end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ website_local: website_build
 	rm -rf _includes
 	export JEKYLL_ENV=development
 build:
+	set -o pipefail; \
 	rm -f env/build_$(ARCH).log && \
 		cd env && \
 		docker build -t $(image) \
@@ -78,12 +79,14 @@ build:
 		tee build_$(ARCH).log && \
 		docker tag $(image) gds:latest
 build_code:
+	set -o pipefail; \
 	cd frontend_code && \
 		docker build -t $(code_image) --progress=plain -f Dockerfile \
 		--build-arg base_image=$(image) . 2>&1 | \
 		tee build_$(ARCH).log && \
 		docker tag $(code_image) gds_code:latest
 build_agent:
+	set -o pipefail; \
 	cd frontend_agent && \
 		docker build -t $(agent_image) --progress=plain -f Dockerfile \
 		--build-arg base_image=$(image) \

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -8,7 +8,7 @@ ENV GDS_ENV_VERSION=$GDS_ENV_VERSION
 ARG BUILDARCH
 
 # https://github.com/ContinuumIO/docker-images/blob/master/miniconda3/Dockerfile
-ENV LANG="C.UTF-8 LC_ALL=C.UTF-8"
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
 RUN echo "Starting build of GDS env $GDS_ENV_VERSION for $BUILDARCH at: $(date)"
 

--- a/env/installers/install_decktape.sh
+++ b/env/installers/install_decktape.sh
@@ -69,19 +69,28 @@ mkdir "$HOME/.decktape" \
 # We fetch Chromium with Playwright on BOTH architectures. Playwright ships
 # prebuilt Linux Chromium for amd64 and arm64, so this replaces the old per-arch
 # puppeteer(amd64)/playwright(arm64) split — a source of the historical
-# amd64-vs-arm64 divergence. Playwright installs into a deterministic layout,
-# `$PLAYWRIGHT_BROWSERS_PATH/chromium-<rev>/chrome-linux/chrome`, so a single
-# glob resolves the binary; the previous find-cascade + zip fallbacks are gone.
-# Nothing is version-pinned — DeckTape and Chromium track latest (see the
-# repo's "latest for tools" policy); robustness comes from the deterministic
-# install path, not from a pin.
+# amd64-vs-arm64 divergence. Nothing is version-pinned — DeckTape and Chromium
+# track latest (see the repo's "latest for tools" policy).
 npm install -g decktape \
  && npm cache clean --force
 
 PLAYWRIGHT_BROWSERS_PATH="$decktape_browser_dir" \
     npx --yes playwright@latest install chromium
 
-chrome_bin="$(ls -d "$decktape_browser_dir"/chromium-*/chrome-linux/chrome | sort | tail -n 1)"
+# Resolve the Chromium binary. Playwright's on-disk layout is NOT stable across
+# versions: Chrome-for-Testing builds extract to `chrome-linux64/chrome`, older
+# builds to `chrome-linux/chrome`. Match either full-browser layout, then fall
+# back to the headless shell — a single fixed glob (e.g. chromium-*/chrome-linux)
+# silently breaks whenever that layout changes.
+chrome_bin="$(find "$decktape_browser_dir" \
+    \( -path '*/chrome-linux/chrome' -o -path '*/chrome-linux64/chrome' \) \
+    -type f 2>/dev/null | sort | tail -n 1)"
+if [ -z "$chrome_bin" ]; then
+  chrome_bin="$(find "$decktape_browser_dir" \
+      \( -path '*/chrome-headless-shell/chrome-headless-shell' \
+      -o -path '*/chrome-headless-shell-linux64/chrome-headless-shell' \) \
+      -type f 2>/dev/null | sort | tail -n 1)"
+fi
 test -n "$chrome_bin"
 test -x "$chrome_bin"
 printf 'Resolved DeckTape Chrome path: %s\n' "$chrome_bin"

--- a/env/installers/install_latex_tools.sh
+++ b/env/installers/install_latex_tools.sh
@@ -20,6 +20,14 @@ mkdir texcount_tmp \
 # latexmk drives jupyter-book's `--pdf` export (myst -> TeX -> latexmk); without
 # it `jupyter-book build --pdf` fails with "latexmk: not found". The TeX engines
 # themselves (xelatex/pdflatex) are already present.
+#
+# latexmk is NOT installable here: it is absent from this base image's apt repos
+# ("Unable to locate package latexmk") and the system tlmgr is Debian-disabled.
+# It is a self-contained Perl script, so fetch it straight from CTAN onto PATH.
+# fonts-lmodern still comes from apt.
 apt-get update -qq \
- && apt-get install -y --no-install-recommends fonts-lmodern latexmk \
- && rm -rf /var/lib/apt/lists/*
+ && apt-get install -y --no-install-recommends fonts-lmodern \
+ && rm -rf /var/lib/apt/lists/* \
+ && wget -qO /usr/local/bin/latexmk https://mirror.ctan.org/support/latexmk/latexmk.pl \
+ && chmod +x /usr/local/bin/latexmk \
+ && latexmk --version | head -1


### PR DESCRIPTION
Gets the amd64 `gds` image building cleanly and the dev-stack `jupyter-book --pdf` test passing. Four small, independent fixes (each validated against a running image before rebuild; full `make build` + `make test` pass on amd64).

## Commits

- **`fix(env): correct malformed ENV LANG assignment (audit 2.3)`** — `ENV LANG="C.UTF-8 LC_ALL=C.UTF-8"` assigned the whole string to `LANG` and never set `LC_ALL`. Use Docker's two-variable form. Verified `locale` is clean in the image.
- **`fix(env): install latexmk from CTAN, not apt`** — `jupyter-book build --pdf` produced no PDF because `latexmk` was never installed: it's absent from this base image's apt repos (`Unable to locate package latexmk`) and the system `tlmgr` is Debian-disabled. latexmk is a self-contained Perl script, so fetch it from CTAN onto `/usr/local/bin` and verify it runs. Validated: `--pdf` now produces a 27 KB PDF via xelatex.
- **`fix(env): robust DeckTape Chromium discovery on amd64`** — the install step located Chromium with a single fixed glob `ls -d chromium-*/chrome-linux/chrome`. Playwright now ships Chrome for Testing, which extracts to `chrome-linux64/chrome`, so the glob matched nothing and the build died at step 12/22. Replaced with a `find` that matches either full-browser layout (`chrome-linux/` or `chrome-linux64/`) and falls back to the headless shell. Validated against a real `npx playwright install chromium`.
- **`fix(make): pipefail on build targets so failed builds fail`** — `docker build … | tee build.log && docker tag … gds:latest` returned tee's exit status (always 0), so a failed build still re-tagged a stale image as `gds:latest` and `make test` silently tested the wrong image. Added `set -o pipefail` to `build` / `build_code` / `build_agent` (matching the `PIPESTATUS` guard already in `test`).

## Validation

- `make build` (amd64) completes all 22 steps.
- `make test` passes, including the dev-stack `jupyter-book --pdf` / `--typst` exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)